### PR TITLE
Add command line argument to enable camera in non interactive mode

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -1047,6 +1047,12 @@ do
     do_apply_os_config
     exit $?
     ;;
+  --enable-camera)
+    INTERACTIVE=False
+    printf "Please reboot\n"
+    set_camera 1
+    exit $?
+    ;;
   nonint)
     INTERACTIVE=False
     $@


### PR DESCRIPTION
allows to run raspi-config to enable the camera in non interactive mode.
Just run it with

```sudo ./raspi-config --enable camera```

Would be great if there would be such a possibility for all parameters that can be changed using raspi-config